### PR TITLE
Remove PersistentVolume because it fails to initialize

### DIFF
--- a/kubernetes/deploy/database.yml
+++ b/kubernetes/deploy/database.yml
@@ -1,16 +1,3 @@
-kind: PersistentVolume
-apiVersion: v1
-metadata:
-  name: tessa-backend-postgres-pv-volume
-  labels:
-    app: postgres
-spec:
-  storageClassName: gp2
-  capacity:
-    storage: 5Gi
-  accessModes:
-    - ReadWriteOnce
----
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
The PV has failed to be created with each deploy, but the database seems have been initialized in the mounted volume without it.