### PR TITLE
Update authorization helper to allow GitHub org members instead of repo collaborators

### DIFF
--- a/src/__tests__/facetsRouter.js
+++ b/src/__tests__/facetsRouter.js
@@ -1,9 +1,11 @@
-const { collectionEnvelope } = require("../responseEnvelopes");
+const { collectionEnvelope, itemEnvelope } = require("../responseEnvelopes");
 const { createAppAgentForRouter } = require("../routerTestUtils");
 const facetsRouter = require("../facetsRouter");
-const { listFacets } = require("../facetsService");
+const { isAdmin } = require("../authMiddleware");
+const { listFacets, createFacet } = require("../facetsService");
 
 jest.mock("../facetsService");
+jest.mock("../authMiddleware");
 
 describe("facetsRouter", () => {
   const appAgent = createAppAgentForRouter(facetsRouter);
@@ -15,6 +17,7 @@ describe("facetsRouter", () => {
           id: 1,
           name: "test name",
           recommendation_prompt: "test recommendation prompt",
+          sort_order: 0,
         },
       ];
       listFacets.mockResolvedValueOnce(facets);
@@ -22,6 +25,108 @@ describe("facetsRouter", () => {
         expect(listFacets).toHaveBeenCalled();
         done(err);
       });
+    });
+  });
+
+  describe("POST /", () => {
+    beforeEach(() => {
+      isAdmin.mockImplementation((req, res, next) => next());
+    });
+
+    it("should create a facet with the given data", (done) => {
+      const name = "test name";
+      const recommendationPrompt = "test recommendation prompt";
+      const sortOrder = 0;
+      const facet = {
+        id: 1,
+        name,
+        recommendation_prompt: recommendationPrompt,
+        sort_order: sortOrder,
+      };
+      createFacet.mockResolvedValueOnce(facet);
+      appAgent
+        .post("/")
+        .send({
+          name: name,
+          recommendation_prompt: recommendationPrompt,
+          sort_order: sortOrder,
+        })
+        .expect(201, itemEnvelope(facet), (err) => {
+          expect(createFacet).toHaveBeenCalledWith(
+            name,
+            recommendationPrompt,
+            sortOrder
+          );
+          done(err);
+        });
+    });
+
+    it("should respond with an unprocessable entity error if name is not sent", (done) => {
+      appAgent
+        .post("/")
+        .send({
+          recommendation_prompt: "test recommendation prompt",
+          sort_order: 0,
+        })
+        .expect(422, done);
+    });
+
+    it("should respond with an unprocessable entity error if name is not valid", (done) => {
+      appAgent
+        .post("/")
+        .send({
+          name: "",
+          recommendation_prompt: "test recommendation prompt",
+          sort_order: 0,
+        })
+        .expect(422, done);
+    });
+
+    it("should respond with an unprocessable entity error if recommendation_prompt is not sent", (done) => {
+      appAgent
+        .post("/")
+        .send({ name: "test name", sort_order: 0 })
+        .expect(422, done);
+    });
+
+    it("should respond with an unprocessable entity error if recommendation_prompt is not valid", (done) => {
+      appAgent
+        .post("/")
+        .send({ name: "test name", recommendation_prompt: "", sort_order: 0 })
+        .expect(422, done);
+    });
+
+    it("should respond with an unprocessable entity error if sort_order is not sent", (done) => {
+      appAgent
+        .post("/")
+        .send({
+          name: "test name",
+          recommendation_prompt: "test recommendation prompt",
+        })
+        .expect(422, done);
+    });
+
+    it("should respond with an unprocessable entity error if sort_order is not valid", (done) => {
+      appAgent
+        .post("/")
+        .send({
+          name: "test name",
+          recommendation_prompt: "test recommendation prompt",
+          sort_order: "bad value",
+        })
+        .expect(422, done);
+    });
+
+    it("should respond with an internal server error if the facet couldn't be created", (done) => {
+      createFacet.mockRejectedValueOnce(new Error());
+      appAgent
+        .post("/")
+        .send({
+          name: "test name",
+          recommendation_prompt: "test recommendation prompt",
+          sort_order: 0,
+        })
+        .expect(500, done);
     });
   });
 });

--- a/src/__tests__/facetsRouter.js
+++ b/src/__tests__/facetsRouter.js
@@ -26,6 +26,11 @@ describe("facetsRouter", () => {
         done(err);
       });
     });
+
+    it("should respond with an internal server error if there is an error querying for the facets", (done) => {
+      listFacets.mockRejectedValueOnce(new Error());
+      appAgent.get("/").expect(500, done);
+    });
   });
 
   describe("POST /", () => {

--- a/src/__tests__/facetsService.js
+++ b/src/__tests__/facetsService.js
@@ -1,4 +1,4 @@
-const { listFacets } = require("../facetsService");
+const { listFacets, createFacet } = require("../facetsService");
 const { mockQuery } = require("../db");
 
 jest.mock("../db");
@@ -11,14 +11,37 @@ describe("facetsService", () => {
           id: 1,
           name: "test name",
           recommendation_prompt: "test recommendation prompt",
+          sort_order: 0,
         },
       ];
       mockQuery(
-        "SELECT id, name, recommendation_prompt FROM facets ORDER BY sort_order;",
+        "SELECT id, name, recommendation_prompt, sort_order FROM facets ORDER BY sort_order;",
         [],
         facets
       );
       expect(await listFacets()).toEqual(facets);
+    });
+  });
+
+  describe("createFacet", () => {
+    it("should insert a facet into the database and return it", async () => {
+      const name = "test name";
+      const recommendationPrompt = "test recommendation prompt";
+      const sortOrder = 0;
+      const facet = {
+        id: 1,
+        name,
+        recommendation_prompt: recommendationPrompt,
+        sort_order: sortOrder,
+      };
+      mockQuery(
+        "INSERT INTO facets (name, recommendation_prompt, sort_order) VALUES ($1, $2, $3) RETURNING id, name, recommendation_prompt, sort_order;",
+        [name, recommendationPrompt, sortOrder],
+        [facet]
+      );
+      expect(await createFacet(name, recommendationPrompt, sortOrder)).toEqual(
+        facet
+      );
     });
   });
 });

--- a/src/__tests__/githubService.js
+++ b/src/__tests__/githubService.js
@@ -2,7 +2,7 @@ const request = require("../request");
 const {
   getAccessToken,
   getGithubUser,
-  isRepoCollaborator,
+  isOrgMember,
 } = require("../githubService");
 
 jest.mock("../request");
@@ -53,21 +53,26 @@ describe("githubService", () => {
     });
   });
 
-  describe("isRepoCollaborator", () => {
-    it("should return whether the user has access to the repo", async () => {
+  describe("isOrgMember", () => {
+    it("should return whether the user is a member of the organization", async () => {
       const accessToken = "test_access_token";
       const mockSet = jest.fn();
+      const mockOk = jest.fn((callback) => {
+        const response = { status: 204 };
+        expect(callback(response)).toBeTruthy();
+        return response;
+      });
       const mockRequest = { set: mockSet };
       mockRequestGet.mockReturnValue(mockRequest);
       mockSet.mockReturnValueOnce(mockRequest);
-      mockSet.mockReturnValueOnce({ status: 204 });
-      const repo = "test-owner/test-repo";
-      const testGithubUsername = "test-github-username";
+      mockSet.mockReturnValueOnce({ ok: mockOk });
+      const organizationName = "test-organization";
+      const githubUsername = "test-github-username";
       expect(
-        await isRepoCollaborator(accessToken, testGithubUsername, repo)
+        await isOrgMember(accessToken, githubUsername, organizationName)
       ).toEqual(true);
       expect(mockRequestGet).toHaveBeenCalledWith(
-        `https://api.github.com/repos/${repo}/collaborators/${testGithubUsername}`
+        `https://api.github.com/orgs/${organizationName}/members/${githubUsername}`
       );
       expect(mockSet).toHaveBeenCalledWith("User-Agent", "TESSA API");
       expect(mockSet).toHaveBeenCalledWith(

--- a/src/__tests__/reflectionsRouter.js
+++ b/src/__tests__/reflectionsRouter.js
@@ -30,6 +30,11 @@ describe("reflectionsRouter", () => {
           done(err);
         });
     });
+
+    it("should respond with an internal server error if there is an error querying for the reflections", (done) => {
+      listReflections.mockRejectedValueOnce(new Error());
+      appAgent.get("/").expect(500, done);
+    });
   });
 
   describe("POST /", () => {
@@ -82,6 +87,15 @@ describe("reflectionsRouter", () => {
         .post("/")
         .send({ statement_id: 2, skill_id: 0 })
         .expect(422, done);
+    });
+
+    it("should respond with an internal server error if there is an error creating the reflection", (done) => {
+      mockUserId(1);
+      createReflection.mockRejectedValueOnce(new Error());
+      appAgent
+        .post("/")
+        .send({ statement_id: 2, skill_id: 3 })
+        .expect(500, done);
     });
   });
 });

--- a/src/__tests__/reflectionsRouter.js
+++ b/src/__tests__/reflectionsRouter.js
@@ -58,30 +58,30 @@ describe("reflectionsRouter", () => {
         });
     });
 
-    it("should respond with a bad request error if statement_id is not sent", (done) => {
+    it("should respond with an unprocessable entity error if statement_id is not sent", (done) => {
       mockUserId(1);
-      appAgent.post("/").send({ skill_id: 2 }).expect(400, done);
+      appAgent.post("/").send({ skill_id: 2 }).expect(422, done);
     });
 
-    it("should respond with a bad request error if skill_id is not sent", (done) => {
+    it("should respond with an unprocessable entity error if skill_id is not sent", (done) => {
       mockUserId(1);
-      appAgent.post("/").send({ statement_id: 2 }).expect(400, done);
+      appAgent.post("/").send({ statement_id: 2 }).expect(422, done);
     });
 
-    it("should respond with a bad request error if statement_id is not a valid id", (done) => {
+    it("should respond with an unprocessable entity error if statement_id is not a valid id", (done) => {
       mockUserId(1);
       appAgent
         .post("/")
         .send({ statement_id: 0, skill_id: 2 })
-        .expect(400, done);
+        .expect(422, done);
     });
 
-    it("should respond with a bad request error if skill_id is not a valid id", (done) => {
+    it("should respond with an unprocessable entity error if skill_id is not a valid id", (done) => {
       mockUserId(1);
       appAgent
         .post("/")
         .send({ statement_id: 2, skill_id: 0 })
-        .expect(400, done);
+        .expect(422, done);
     });
   });
 });

--- a/src/__tests__/skillsRouter.js
+++ b/src/__tests__/skillsRouter.js
@@ -23,6 +23,11 @@ describe("skillsRouter", () => {
         done(err);
       });
     });
+
+    it("should respond with an internal server error if there is an error querying for the skills", (done) => {
+      listSkills.mockRejectedValueOnce(new Error());
+      appAgent.get("/").expect(500, done);
+    });
   });
 
   describe("GET /:id", () => {
@@ -56,6 +61,11 @@ describe("skillsRouter", () => {
         expect(findSkill).not.toHaveBeenCalled();
         done(err);
       });
+    });
+
+    it("should respond with an internal server error if there is an error querying for the skill", (done) => {
+      findSkill.mockRejectedValueOnce(new Error());
+      appAgent.get("/1").expect(500, done);
     });
   });
 });

--- a/src/__tests__/statementsRouter.js
+++ b/src/__tests__/statementsRouter.js
@@ -25,5 +25,10 @@ describe("statementsRouter", () => {
           done(err);
         });
     });
+
+    it("should respond with an internal server error if there is an error querying for the statements", (done) => {
+      listStatements.mockRejectedValueOnce(new Error());
+      appAgent.get("/").expect(500, done);
+    });
   });
 });

--- a/src/__tests__/validators.js
+++ b/src/__tests__/validators.js
@@ -1,4 +1,4 @@
-const { isValidId } = require("../validators");
+const { isValidId, isNonWhitespaceOnlyString } = require("../validators");
 
 describe("validators", () => {
   describe("isValidId", () => {
@@ -16,6 +16,24 @@ describe("validators", () => {
 
     it("should return false if the input is not a number", () => {
       expect(isValidId("1")).toBe(false);
+    });
+  });
+
+  describe("isNonWhitespaceOnlyString", () => {
+    it("should return true if there is text in the string", () => {
+      expect(isNonWhitespaceOnlyString(" a ")).toBe(true);
+    });
+
+    it("should return false if the input is not a string", () => {
+      expect(isNonWhitespaceOnlyString(1)).toBe(false);
+    });
+
+    it("should return false if the input is the empty string", () => {
+      expect(isNonWhitespaceOnlyString("")).toBe(false);
+    });
+
+    it("should return false if the input is only whitespace", () => {
+      expect(isNonWhitespaceOnlyString("\t \r\n")).toBe(false);
     });
   });
 });

--- a/src/authMiddleware.js
+++ b/src/authMiddleware.js
@@ -1,4 +1,4 @@
-const { isRepoCollaborator } = require("./githubService");
+const { isOrgMember } = require("./githubService");
 const { UnauthorizedError } = require("./httpErrors");
 
 exports.isAuthenticated = (req, res, next) => {
@@ -9,13 +9,13 @@ exports.isAuthenticated = (req, res, next) => {
   next(new UnauthorizedError());
 };
 
-exports.isCollaborator = async (req, res, next) => {
-  const hasCollaboratorAccess = await isRepoCollaborator(
-    process.env.GITHUB_ACCESS_TOKEN,
+exports.isMember = (githubOrganizationName) => async (req, res, next) => {
+  const isUserPublicMemberOfOrg = await isOrgMember(
+    req.session.accessToken,
     req.session.githubUsername,
-    "davidvandusen/tessa"
+    githubOrganizationName
   );
-  if (hasCollaboratorAccess) {
+  if (isUserPublicMemberOfOrg) {
     next();
     return;
   }

--- a/src/authMiddleware.js
+++ b/src/authMiddleware.js
@@ -10,12 +10,26 @@ exports.isAuthenticated = (req, res, next) => {
 };
 
 exports.isMember = (githubOrganizationName) => async (req, res, next) => {
+  if (!req.session.githubUsername) {
+    next(new UnauthorizedError());
+    return;
+  }
   const isUserPublicMemberOfOrg = await isOrgMember(
     req.session.accessToken,
     req.session.githubUsername,
     githubOrganizationName
   );
   if (isUserPublicMemberOfOrg) {
+    next();
+    return;
+  }
+  next(new UnauthorizedError());
+};
+
+exports.isAdmin = (req, res, next) => {
+  // HACK While the project is being bootstrapped, userId = 1 will be
+  //      predictably someone who is rightfully an administrator.
+  if (req.session.userId === "1") {
     next();
     return;
   }

--- a/src/authRouter.js
+++ b/src/authRouter.js
@@ -26,7 +26,7 @@ authRouter.get("/github/oauth/callback", async (req, res, next) => {
   if (!user) {
     user = await createUser(githubUser.id, githubUser.login);
   }
-  req.session.userId = user.id;
+  req.session.userId = String(user.id);
   req.session.githubUsername = user.github_username;
   req.session.accessToken = accessToken;
   res.redirect(process.env.WEBAPP_ORIGIN);

--- a/src/authRouter.js
+++ b/src/authRouter.js
@@ -28,6 +28,7 @@ authRouter.get("/github/oauth/callback", async (req, res, next) => {
   }
   req.session.userId = user.id;
   req.session.githubUsername = user.github_username;
+  req.session.accessToken = accessToken;
   res.redirect(process.env.WEBAPP_ORIGIN);
 });
 

--- a/src/facetsRouter.js
+++ b/src/facetsRouter.js
@@ -1,13 +1,61 @@
 const { Router } = require("express");
 
-const { collectionEnvelope } = require("./responseEnvelopes");
-const { listFacets } = require("./facetsService");
+const { collectionEnvelope, itemEnvelope } = require("./responseEnvelopes");
+const { isAdmin } = require("./authMiddleware");
+const { isNonWhitespaceOnlyString } = require("./validators");
+const { listFacets, createFacet } = require("./facetsService");
+const { UnprocessableEntityError } = require("./httpErrors");
 
 const facetsRouter = new Router();
 
 facetsRouter.get("/", async (req, res) => {
   const facets = await listFacets();
   res.json(collectionEnvelope(facets, facets.length));
+});
+
+facetsRouter.post("/", isAdmin, async (req, res, next) => {
+  if (
+    typeof req.body !== "object" ||
+    !("name" in req.body) ||
+    !("recommendation_prompt" in req.body) ||
+    !("sort_order" in req.body)
+  ) {
+    next(
+      new UnprocessableEntityError(
+        "The request body must be an object with name, recommendation_prompt and sort_order properties."
+      )
+    );
+    return;
+  }
+  const {
+    name,
+    recommendation_prompt: recommendationPrompt,
+    sort_order: sortOrder,
+  } = req.body;
+  if (!isNonWhitespaceOnlyString(name)) {
+    next(new UnprocessableEntityError(`"${name}" must contain text.`));
+    return;
+  }
+  if (!isNonWhitespaceOnlyString(recommendationPrompt)) {
+    next(
+      new UnprocessableEntityError(
+        `"${recommendationPrompt}" must contain text.`
+      )
+    );
+    return;
+  }
+  if (!Number.isSafeInteger(sortOrder)) {
+    next(new UnprocessableEntityError(`"${sortOrder}" must be an integer.`));
+    return;
+  }
+  let facet;
+  try {
+    facet = await createFacet(name, recommendationPrompt, sortOrder);
+  } catch (e) {
+    next(e);
+    return;
+  }
+  res.status(201).json(itemEnvelope(facet));
 });
 
 module.exports = facetsRouter;

--- a/src/facetsRouter.js
+++ b/src/facetsRouter.js
@@ -8,8 +8,14 @@ const { UnprocessableEntityError } = require("./httpErrors");
 
 const facetsRouter = new Router();
 
-facetsRouter.get("/", async (req, res) => {
-  const facets = await listFacets();
+facetsRouter.get("/", async (req, res, next) => {
+  let facets;
+  try {
+    facets = await listFacets();
+  } catch (e) {
+    next(e);
+    return;
+  }
   res.json(collectionEnvelope(facets, facets.length));
 });
 

--- a/src/facetsService.js
+++ b/src/facetsService.js
@@ -2,7 +2,17 @@ const db = require("./db");
 
 exports.listFacets = async () => {
   const { rows: facets } = await db.query(
-    "SELECT id, name, recommendation_prompt FROM facets ORDER BY sort_order;"
+    "SELECT id, name, recommendation_prompt, sort_order FROM facets ORDER BY sort_order;"
   );
   return facets;
+};
+
+exports.createFacet = async (name, recommendationPrompt, sortOrder) => {
+  const {
+    rows: [facet],
+  } = await db.query(
+    "INSERT INTO facets (name, recommendation_prompt, sort_order) VALUES ($1, $2, $3) RETURNING id, name, recommendation_prompt, sort_order;",
+    [name, recommendationPrompt, sortOrder]
+  );
+  return facet;
 };

--- a/src/githubService.js
+++ b/src/githubService.js
@@ -22,10 +22,13 @@ exports.getGithubUser = async (accessToken) => {
   return response.body;
 };
 
-exports.isRepoCollaborator = async (accessToken, githubUsername, repo) => {
+exports.isOrgMember = async (accessToken, githubUsername, organizationName) => {
   const response = await request
-    .get(`https://api.github.com/repos/${repo}/collaborators/${githubUsername}`)
+    .get(
+      `https://api.github.com/orgs/${organizationName}/members/${githubUsername}`
+    )
     .set("User-Agent", "TESSA API")
-    .set("Authorization", `token ${accessToken}`);
+    .set("Authorization", `token ${accessToken}`)
+    .ok(({ status }) => status);
   return response.status === 204;
 };

--- a/src/httpErrors.js
+++ b/src/httpErrors.js
@@ -20,5 +20,11 @@ NotFoundError.prototype.message = "The requested resource does not exist.";
 NotFoundError.prototype.status = 404;
 exports.NotFoundError = NotFoundError;
 
+class UnprocessableEntityError extends HttpError {}
+UnprocessableEntityError.prototype.message =
+  "The content body of the request is not valid.";
+UnprocessableEntityError.prototype.status = 422;
+exports.UnprocessableEntityError = UnprocessableEntityError;
+
 class InternalServerError extends HttpError {}
 exports.InternalServerError = InternalServerError;

--- a/src/reflectionsRouter.js
+++ b/src/reflectionsRouter.js
@@ -7,9 +7,15 @@ const { UnprocessableEntityError } = require("./httpErrors");
 
 const reflectionsRouter = new Router();
 
-reflectionsRouter.get("/", async (req, res) => {
+reflectionsRouter.get("/", async (req, res, next) => {
   const { userId } = req.session;
-  const reflections = await listReflections(userId);
+  let reflections;
+  try {
+    reflections = await listReflections(userId);
+  } catch (e) {
+    next(e);
+    return;
+  }
   res.json(collectionEnvelope(reflections, reflections.length));
 });
 
@@ -41,7 +47,13 @@ reflectionsRouter.post("/", async (req, res, next) => {
     );
     return;
   }
-  const reflection = await createReflection(userId, skillId, statementId);
+  let reflection;
+  try {
+    reflection = await createReflection(userId, skillId, statementId);
+  } catch (e) {
+    next(e);
+    return;
+  }
   res.status(201).json(itemEnvelope(reflection));
 });
 

--- a/src/reflectionsRouter.js
+++ b/src/reflectionsRouter.js
@@ -3,7 +3,7 @@ const { Router } = require("express");
 const { collectionEnvelope, itemEnvelope } = require("./responseEnvelopes");
 const { createReflection, listReflections } = require("./reflectionsService");
 const { isValidId } = require("./validators");
-const { BadRequestError } = require("./httpErrors");
+const { UnprocessableEntityError } = require("./httpErrors");
 
 const reflectionsRouter = new Router();
 
@@ -17,7 +17,7 @@ reflectionsRouter.post("/", async (req, res, next) => {
   const { userId } = req.session;
   if (!("skill_id" in req.body) || !("statement_id" in req.body)) {
     next(
-      new BadRequestError(
+      new UnprocessableEntityError(
         "The request body must have skill_id and statement_id properties."
       )
     );
@@ -26,14 +26,16 @@ reflectionsRouter.post("/", async (req, res, next) => {
   const skillId = Number(req.body.skill_id);
   if (!isValidId(skillId)) {
     next(
-      new BadRequestError(`"${req.body.skill_id}" is not a valid skill id.`)
+      new UnprocessableEntityError(
+        `"${req.body.skill_id}" is not a valid skill id.`
+      )
     );
     return;
   }
   const statementId = Number(req.body.statement_id);
   if (!isValidId(statementId)) {
     next(
-      new BadRequestError(
+      new UnprocessableEntityError(
         `"${req.body.statement_id}" is not a valid statement id.`
       )
     );

--- a/src/skillsRouter.js
+++ b/src/skillsRouter.js
@@ -7,8 +7,14 @@ const { isValidId } = require("./validators");
 
 const skillsRouter = new Router();
 
-skillsRouter.get("/", async (req, res) => {
-  const skills = await listSkills();
+skillsRouter.get("/", async (req, res, next) => {
+  let skills;
+  try {
+    skills = await listSkills();
+  } catch (e) {
+    next(e);
+    return;
+  }
   res.json(collectionEnvelope(skills, skills.length));
 });
 
@@ -19,7 +25,13 @@ skillsRouter.get("/:id", async (req, res, next) => {
     next(new BadRequestError(`"${id}" is not a valid skill id.`));
     return;
   }
-  const skill = await findSkill(skillId);
+  let skill;
+  try {
+    skill = await findSkill(skillId);
+  } catch (e) {
+    next(e);
+    return;
+  }
   if (!skill) {
     next(new NotFoundError(`A skill with the id "${id}" could not be found.`));
     return;

--- a/src/statementsRouter.js
+++ b/src/statementsRouter.js
@@ -5,8 +5,14 @@ const { listStatements } = require("./statementsService");
 
 const statementsRouter = new Router();
 
-statementsRouter.get("/", async (req, res) => {
-  const statements = await listStatements();
+statementsRouter.get("/", async (req, res, next) => {
+  let statements;
+  try {
+    statements = await listStatements();
+  } catch (e) {
+    next(e);
+    return;
+  }
   res.json(collectionEnvelope(statements, statements.length));
 });
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,1 +1,4 @@
 exports.isValidId = (id) => Number.isInteger(id) && id > 0;
+
+exports.isNonWhitespaceOnlyString = (str) =>
+  typeof str === "string" && str.trim() !== "";


### PR DESCRIPTION
Previously the rule was going to be that anyone who is a collaborator on the repo was allowed to write content to TESSA.

Now that we have the Commit Community GitHub organization, it's a much better fit to the business rule of "Commit Community members are allowed to share recommendations" to use membership for authorization.

As long as users' membership status is public, no scopes are needed to make the API call, so the `GITHUB_ACCESS_TOKEN` environment variable isn't needed, and no scopes need to be added to the OAuth flow.