### PR TITLE
Add ORDER BY to skills by reflection SQL to ensure latest is always used

### DIFF
--- a/src/__tests__/reflectionsService.js
+++ b/src/__tests__/reflectionsService.js
@@ -37,7 +37,7 @@ describe("reflectionsService", () => {
       const skillId = "4";
       const skillId2 = "5";
       mockQuery(
-        "SELECT DISTINCT ON (s.facet_id, r.skill_id) s.facet_id, r.statement_id, r.skill_id, MAX(r.created_at) FROM reflections r JOIN statements s ON r.statement_id = s.id WHERE r.user_id = $1 GROUP BY s.facet_id, r.statement_id, r.skill_id;",
+        "SELECT DISTINCT ON (s.facet_id, r.skill_id) s.facet_id, r.statement_id, r.skill_id, MAX(r.created_at) max_created_at FROM reflections r JOIN statements s ON r.statement_id = s.id WHERE r.user_id = $1 GROUP BY s.facet_id, r.statement_id, r.skill_id ORDER BY s.facet_id, r.skill_id, max_created_at DESC;",
         [userId],
         [
           { facet_id: facetId, statement_id: statementId, skill_id: skillId },

--- a/src/reflectionsService.js
+++ b/src/reflectionsService.js
@@ -10,7 +10,7 @@ exports.listReflections = async (userId) => {
 
 exports.listSkillsOfLatestReflectionsByFacetStatements = async (userId) => {
   const { rows } = await db.query(
-    "SELECT DISTINCT ON (s.facet_id, r.skill_id) s.facet_id, r.statement_id, r.skill_id, MAX(r.created_at) FROM reflections r JOIN statements s ON r.statement_id = s.id WHERE r.user_id = $1 GROUP BY s.facet_id, r.statement_id, r.skill_id;",
+    "SELECT DISTINCT ON (s.facet_id, r.skill_id) s.facet_id, r.statement_id, r.skill_id, MAX(r.created_at) max_created_at FROM reflections r JOIN statements s ON r.statement_id = s.id WHERE r.user_id = $1 GROUP BY s.facet_id, r.statement_id, r.skill_id ORDER BY s.facet_id, r.skill_id, max_created_at DESC;",
     [userId]
   );
   const separator = ":";


### PR DESCRIPTION
When the user had changed their mind about which statement to save for a facet of a skill, the reflections page would show the latest reflection of the statement with the lowest primary key. This forces it to use the one with the highest created_at instead.